### PR TITLE
[READY] Strip carriage returns as causes checksum error in SDK

### DIFF
--- a/models/sqs.rb
+++ b/models/sqs.rb
@@ -27,7 +27,7 @@ module Spurious
         end
 
         def self.send_message(queue_name, message)
-          queue(queue_name).send_message(message)
+          queue(queue_name).send_message(message.gsub(/\r?\n/, ''))
         end
 
         def self.clear(queue_name)


### PR DESCRIPTION
### Problem

When sending a SQS message with spurious browser, if there were carriage returns present in the message this caused there to be a checksum mismatch as when the message was received the carriage returns had already been interpolated causing the md5 to differ from the one generated with the message.
### Solution

Strip any carriage returns and new lines from the message before sending it.
