### PR TITLE
[READY] Show object count and get prefix name correctly

### DIFF
--- a/templates/s3.mustache
+++ b/templates/s3.mustache
@@ -10,14 +10,13 @@
     <table class="table">
       <thead>
         <th>Name</th>
-        <th width="70%">Url</th>
-        <!-- <th colspan="2" width="7%"></th> -->
+        <th width="70%">Objects</th>
       </thead>
       <tbody>
         {{# buckets}}
         <tr>
         <td><a href="/s3/{{ name }}">{{ name }}</a></td>
-        <td>{{ url }}</td>
+        <td>{{ objects }}</td>
         <!-- <td> -->
         <!-- 	<a href="/s3/{{ name }}/clear" title="Clear messages"><span class="glyphicon glyphicon-trash"></span></a> -->
         <!-- </td> -->


### PR DESCRIPTION
After merging a few PR's from the upstream [fake-s3](https://github.com/jubos/fake-s3) s3 repo, a few changes were needed to get the folder names correctly.

> Also removed the URL as it's misleading and changed for number of objects in bucket (Arguably more useful).
